### PR TITLE
bugfix/fix path for windows + add model to lfs

### DIFF
--- a/spacy_huggingface_hub/push.py
+++ b/spacy_huggingface_hub/push.py
@@ -90,7 +90,7 @@ def push(
     repo = Repository(repo_local_path, clone_from=repo_url)
     repo.git_pull(rebase=True)
     # TODO: Are there other files we need to add here?
-    repo.lfs_track(["*.whl", "*.npz", "*strings.json", "vectors"])
+    repo.lfs_track(["*.whl", "*.npz", "*strings.json", "vectors", "model"])
     info_msg = f"Publishing to repository '{repo_name}'"
     if namespace is not None:
         info_msg += f" ({namespace})"
@@ -100,7 +100,7 @@ def push(
     with zipfile.ZipFile(whl_path, "r") as zip_ref:
         base_name = Path(repo_name) / versioned_name
         for file_name in zip_ref.namelist():
-            if file_name.startswith(str(base_name)):
+            if str(Path(file_name)).startswith(str(base_name)):
                 zip_ref.extract(file_name, local_repo_path)
     msg.good("Extracted information from .whl file")
 


### PR DESCRIPTION
+ `zip_ref.namelist()` produces a different path format than `Path()`, that's why for **windows** the `base_layer` and `file_name` couldn't be compared. Because of that, the `if file_name.startswith(str(base_name)):` statement was never true.
The fix was to format `file_name` to the same format as `base_name` when using `.startswith()`.

+ `model` was added to `repo.lfs_track()` because it's size exceeded `10 Mb`, at least for windows