### PR TITLE
Fix model-index structure and misc minor fixes

### DIFF
--- a/spacy_huggingface_hub/push.py
+++ b/spacy_huggingface_hub/push.py
@@ -75,7 +75,6 @@ def push(
     filename = whl_path.stem
     repo_name, version, _, _, _ = filename.split("-")
     versioned_name = repo_name + "-" + version
-
     repo_local_path = Path(local_repo_path) / repo_name
 
     # Create the repo (or clone its content if it's nonempty)


### PR DESCRIPTION
This PR has multiple changes, including:
* Allowing to push an unversioned `whl` name (recall that repos in HF have `whl` files with `any` version in the name, and the extraction happens differently for those). 
* Add the task to the metric name
* Change the `model-index` in the metadata to match latest specification.

This will enable showing a "Evaluation Results" section in the model card
<img width="523" alt="Screen Shot 2021-08-10 at 10 58 28 PM" src="https://user-images.githubusercontent.com/7246357/128934154-554c08bb-2791-45e6-b364-6f5bf8512416.png">

FYI @julien-c