### PR TITLE
Use new non-git based API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ To check if the command has been registered successfully:
 python -m spacy huggingface-hub --help
 ```
 
-Hugging Face uses **Git Large File Storage** (LFS) to handle files larger than 10mb. You can find instructions on how to download it [here](https://git-lfs.github.com/).
 
-You can then upload any pipeline packaged with [`spacy package`](https://spacy.io/api/cli#package). Make sure to set `--build wheel` to output a binary `.whl` file. The uploader will read all metadata from the pipeline package, including the auto-generated pretty `README.md` and the model details available in the `meta.json`.
+You can upload any pipeline packaged with [`spacy package`](https://spacy.io/api/cli#package). Make sure to set `--build wheel` to output a binary `.whl` file. The uploader will read all metadata from the pipeline package, including the auto-generated pretty `README.md` and the model details available in the `meta.json`.
 
 ```bash
 huggingface-cli login
@@ -68,7 +67,6 @@ python -m spacy_huggingface_hub push [whl_path] [--org] [--msg] [--local-repo] [
 | `whl_path`           | str / `Path` | The path to the `.whl` file packaged with [`spacy package`](https://spacy.io/api/cli#package).                                |
 | `--org`, `-o`        | str          | Optional name of organization to which the pipeline should be uploaded.                                                       |
 | `--msg`, `-m`        | str          | Commit message to use for update. Defaults to `"Update spaCy pipeline"`.                                                      |
-| `--local-repo`, `-l` | str / `Path` | Local path to the model repository (will be created if it doesn't exist). Defaults to `hub` in the current working directory. |
 | `--verbose`, `-V`    | bool         | Output additional info for debugging, e.g. the full generated hub metadata.                                                   |
 
 ### Usage from Python

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 [options]
 python_requires = >=3.6
 install_requires =
-    huggingface_hub==0.0.12
+    huggingface_hub==0.8.1
     wasabi>=0.8.1,<1.1.0
     typer>=0.3.0,<0.4.0
     PyYAML


### PR DESCRIPTION
With this approach:
* Users don't need to configure git or use git lfs
* A local copy of the repo is not needed anymore, so no local artifacts and issues related to git conflicts anymore
* Due to above, `--local-repo` flag is removed.
* Some light cleanup of codebase, in particular there was an edge scenario when the version is not specified in the `whl` name (which is the case of the whl on the HF Hub), and it was not being handled appropriately. Now we retrieve the version from the metadata file if the version is not specified

Result: https://huggingface.co/osanseviero/en_core_web_sm